### PR TITLE
Activate links readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to [PSL standards](/core/Standards/project_standards.md) for transparancy. Many modeling projects also adopt PSL's guidelines for interoperability and community building, which take the form of suggestions for interface design and organizational activity. PSL aims to grow to span governments and policy domains. 
+The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to [PSL standards](/Core/Standards/project_standards.md) for transparancy. Many modeling projects also adopt PSL's guidelines for interoperability and community building, which take the form of suggestions for interface design and organizational activity. PSL aims to grow to span governments and policy domains. 
 
 The PSL-Core project, which lives in this repository, sets PSL standards and develops infrastructure to support PSL. 
 
@@ -9,7 +9,7 @@ PSL-Core infrastructure projects under development include:
 - Broadcast-Recipes for disseminating updates about the projects to users. 
 - A privacy-granting service to repost user questions on our community message boards. For example, "A Congressional user from an important committee would like to know _____."
 
-If you would like to learn more about PSL plans, see our [roadmap](/core/community/roadmap.md). 
+If you would like to learn more about PSL plans, see our [roadmap](/Core/Community/roadmap.md). 
 
-If you would like to make a technical contribution to PSL-Core, please review the [contributor guide](/core/community/contribute.md). 
+If you would like to make a technical contribution to PSL-Core, please review the [contributor guide](/Core/Community/contribute.md). 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to [PSL standards](core/Standards/project_standards.md) for transparancy. Many modeling projects also adopt PSL's guidelines for interoperability and community building, which take the form of suggestions for interface design and organizational activity. PSL aims to grow to span governments and policy domains. 
+The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to [PSL standards](/core/Standards/project_standards.md) for transparancy. Many modeling projects also adopt PSL's guidelines for interoperability and community building, which take the form of suggestions for interface design and organizational activity. PSL aims to grow to span governments and policy domains. 
 
 The PSL-Core project, which lives in this repository, sets PSL standards and develops infrastructure to support PSL. 
 
@@ -9,7 +9,7 @@ PSL-Core infrastructure projects under development include:
 - Broadcast-Recipes for disseminating updates about the projects to users. 
 - A privacy-granting service to repost user questions on our community message boards. For example, "A Congressional user from an important committee would like to know _____."
 
-If you would like to learn more about PSL plans, see our [roadmap](core/community/roadmap.md). 
+If you would like to learn more about PSL plans, see our [roadmap](/core/community/roadmap.md). 
 
-If you would like to make a technical contribution to PSL-Core, please review the [contributor guide](core/community/contribute.md). 
+If you would like to make a technical contribution to PSL-Core, please review the [contributor guide](/core/community/contribute.md). 
 


### PR DESCRIPTION
This PR fixes and activates links in the README to the standards, contributor guide, and roadmap. 