### PR TITLE
standards and guidelines -> criteria

### DIFF
--- a/Core/Community/roadmap.md
+++ b/Core/Community/roadmap.md
@@ -1,10 +1,10 @@
-1. Release 0.1.0 of PSL-core with a set of standards that serve as admittance criteria to the library and an initial framework for the library and its growth.
-1. Incorporate Tax-Calculator, B-Tax, and OG-USA into PSL by satisfying PSL standards and submitting the models through a defined submission process. 
-1. Release a PSL-Catalog of projects and their key attributes, compiled automatticly from member projects based on their conformance to interoperability guidlines.
+1. Release 0.1.0 of PSL-core with a set of criteria for the library and an initial framework its growth.
+1. Incorporate Tax-Calculator, B-Tax, and OG-USA into PSL by satisfying PSL criteria and submitting the models through a defined submission process. 
+1. Release a PSL-Catalog of projects and their key attributes, compiled automatticly from member projects based on their conformance to interoperability criteria.
 1. Release policysimulationlibrary.org 
 1. Release PSL-Broadcast-Recipes and initiate PSL social media and email. 
-1. Release PSL Standards-Tests that projects can adopt in their own repositories to test their conformance to PSL standards and guidlines. 
-1. Release PSL Standards 1.0.0
+1. Release PSL Criteria-Tests that projects can adopt in their own repositories to test their conformance to PSL criteria. 
+1. Release PSL-core 1.0.0
 
 
 

--- a/Core/Criteria/library_criteria.md
+++ b/Core/Criteria/library_criteria.md
@@ -1,5 +1,5 @@
 
-Policy Simulation Library Project Standards
+Policy Simulation Library Project Criteria
 ============================================
 
 Summary
@@ -14,9 +14,9 @@ Introduction
 
 Open-source modeling ensures that model results are reproducible, that experts around the world can collaborate to make models better, and that users can explore the parameter space for themselves. These outcomes systematically improve public policy decisionmaking. 
 
-We have developed the standards and guidelines in this document to fascilitate the growth of an open source public policy modeling ecosystem.
+We have developed the criteria in this document to fascilitate the growth of an open source public policy modeling ecosystem.
 
-Standards for transparancy and quality
+Criteria for transparancy and quality
 ---------
 -------------------------
 
@@ -35,7 +35,7 @@ Standards for transparancy and quality
 1. Projects MUST have installation directions. 
 1. Project MUST be mirrored in the same GitHub organization as PSL-Core.
 
-Guidelines for community
+Criteria for community
 ------------------------
 
 1. Projects SHOULD have a public roadmap.
@@ -50,12 +50,12 @@ Guidelines for community
 1. Projects SHOULD have a changelog. 
 1. Projects MAY have a Stack Overflow channel. 
 1. Projects MAY include a "News" translation of the changelog for users. 
-1. Projects MAY include standards for participating in cross-model PSL initiatives. 
+1. Projects MAY include criteria for participating in cross-model PSL initiatives. 
 1. Projects MAY include a link to a webapp verison. 
 1. Projects MAY include a list of consultants. 
 
 
-Guidlines for interoperability
+Criteria for interoperability
 ------------- 
 
 1. The source code SHOULD be written in an open source language. 

--- a/Core/Criteria/library_criteria.md
+++ b/Core/Criteria/library_criteria.md
@@ -16,9 +16,9 @@ Open-source modeling ensures that model results are reproducible, that experts a
 
 We have developed the criteria in this document to fascilitate the growth of an open source public policy modeling ecosystem.
 
-Criteria for transparancy and quality
----------
--------------------------
+Acceptance Criteria for Transparancy and Quality 
+--------------------------------------------
+--------------------------------------------
 
 1. Models MUST be released under an OSI-approved opens source license.   
 1. Data MUST be publicly available, unless release is restricted by a third party. 
@@ -35,8 +35,8 @@ Criteria for transparancy and quality
 1. Projects MUST have installation directions. 
 1. Project MUST be mirrored in the same GitHub organization as PSL-Core.
 
-Criteria for community
-------------------------
+Community Criteria
+-------------------
 
 1. Projects SHOULD have a public roadmap.
 1. Projects SHOULD have contributor documentation and guidelines. 
@@ -55,8 +55,8 @@ Criteria for community
 1. Projects MAY include a list of consultants. 
 
 
-Criteria for interoperability
-------------- 
+Interoperability Criteria
+--------------------------
 
 1. The source code SHOULD be written in an open source language. 
 1. All input and output variables SHOULD be documented like...

--- a/Core/Tools/Catalog-Builder/README.md
+++ b/Core/Tools/Catalog-Builder/README.md
@@ -1,1 +1,1 @@
-This directory will contain the Catalog-Builder, which will automatically generate the PSL Catalog by relying on PSL interoperability guidlines.  
+This directory will contain the Catalog-Builder, which will automatically generate the PSL Catalog by relying on PSL interoperability criteria.  

--- a/Core/Tools/Standards-Tests/README.md
+++ b/Core/Tools/Standards-Tests/README.md
@@ -1,1 +1,1 @@
-This directory will contain tests to check conformance of modeling projects to PSL standards and guidlines. 
+This directory will contain tests to check conformance of modeling projects to PSL criteria. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to [PSL standards](/Core/Standards/project_standards.md) for transparancy. Modeling projects may also adopt PSL's guidelines for interoperability and community building, which take the form of suggestions for interface design and organizational activity. PSL aims to grow to span governments and policy domains. 
+The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to [PSL criteria](/Core/Criteria/project_criteria.md) for transparancy. Modeling projects may also adopt PSL's criteria for interoperability and community building, which take the form of suggestions for interface design and organizational activity. PSL aims to grow to span governments and policy domains. 
 
-The PSL-Core project, which lives in this repository, sets PSL standards and develops infrastructure to support PSL. 
+The PSL-Core project, which lives in this repository, sets PSL criteria and develops infrastructure to support PSL. 
 
 PSL-Core infrastructure projects under development include:
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,16 +10,16 @@ for a complete commit history.
 [#X](https://github.com/open-source-economics/PSL-core/pull/X))
 
 **API Changes**
-Includes substantive changes to standards or tooling capabilities and reports the loss of a model from the library.
+Includes substantive changes to criteria or tooling capabilities and reports the loss of a model from the library.
 - 
 
 **New Features**
 Include new tooling capabilities, new models, and model updates.
 - Initial directory structure [____ by Matt Jensen and]
-- Initial standards [____ by Matt Jensen and]
+- Initial criteria [____ by Matt Jensen and]
 - Initial roadmap [ ____ by Matt Jensen and]
 - Initial RELEASES.md structure [ ____ by Matt Jensen based on Tax-Calculator]
 
 **Bug Fixes**
-Includes substantive bug fixes to standards and tooling.
+Includes substantive bug fixes to criteria and tooling.
 - 


### PR DESCRIPTION
I was inspired by the the Linux Foundation's [Core Infrastructure Initiative](https://www.coreinfrastructure.org/programs/badge-program/) to replace our usage of "Standards" and "Guidelines" with "criteria."  

I will leave this up for a few days in case someone objects. 