### PR TITLE
update home page, remove donations. FAQ

### DIFF
--- a/Core/Tools/Web/pages/about.html
+++ b/Core/Tools/Web/pages/about.html
@@ -14,8 +14,8 @@
             <ul class="navbar-nav">
                 <li class="nav-item"><a href="about.html" class="nav-link">About PSL</a></li>
                 <li class="nav-item"><a href="models.html" class="nav-link">Models</a></li>
-                <li class="nav-item"><a href="donate.html" class="nav-link">Donate</a></li>
-                <li class="nav-item"><a href="faq.html" class="nav-link">FAQ</a></li>
+                <!-- <li class="nav-item"><a href="donate.html" class="nav-link">Donate</a></li>
+                <li class="nav-item"><a href="faq.html" class="nav-link">FAQ</a></li> -->
             </ul>
         </nav>
         <div class="container">

--- a/Core/Tools/Web/pages/donate.html
+++ b/Core/Tools/Web/pages/donate.html
@@ -14,8 +14,8 @@
             <ul class="navbar-nav">
                 <li class="nav-item"><a href="about.html" class="nav-link">About PSL</a></li>
                 <li class="nav-item"><a href="models.html" class="nav-link">Models</a></li>
-                <li class="nav-item"><a href="donate.html" class="nav-link">Donate</a></li>
-                <li class="nav-item"><a href="faq.html" class="nav-link">FAQ</a></li>
+                <!-- <li class="nav-item"><a href="donate.html" class="nav-link">Donate</a></li>
+                <li class="nav-item"><a href="faq.html" class="nav-link">FAQ</a></li> -->
             </ul>
         </nav>
         <div class="container">

--- a/Core/Tools/Web/pages/faq.html
+++ b/Core/Tools/Web/pages/faq.html
@@ -14,8 +14,8 @@
             <ul class="navbar-nav">
                 <li class="nav-item"><a href="about.html" class="nav-link">About PSL</a></li>
                 <li class="nav-item"><a href="models.html" class="nav-link">Models</a></li>
-                <li class="nav-item"><a href="donate.html" class="nav-link">Donate</a></li>
-                <li class="nav-item"><a href="faq.html" class="nav-link">FAQ</a></li>
+                <!-- <li class="nav-item"><a href="donate.html" class="nav-link">Donate</a></li>
+                <li class="nav-item"><a href="faq.html" class="nav-link">FAQ</a></li> -->
             </ul>
         </nav>
         <div class="container">

--- a/Core/Tools/Web/pages/models.html
+++ b/Core/Tools/Web/pages/models.html
@@ -14,8 +14,8 @@
             <ul class="navbar-nav">
                 <li class="nav-item"><a href="about.html" class="nav-link">About PSL</a></li>
                 <li class="nav-item"><a href="models.html" class="nav-link">Models</a></li>
-                <li class="nav-item"><a href="donate.html" class="nav-link">Donate</a></li>
-                <li class="nav-item"><a href="faq.html" class="nav-link">FAQ</a></li>
+                <!-- <li class="nav-item"><a href="donate.html" class="nav-link">Donate</a></li>
+                <li class="nav-item"><a href="faq.html" class="nav-link">FAQ</a></li> -->
             </ul>
         </nav>
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
         <title>PSL Home</title>
         <!-- include bootstrap -->
         <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+        <style>
+            .card-link {color: black;}
+        </style>
     </head>
     <body>
         <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
@@ -14,13 +17,64 @@
             <ul class="navbar-nav">
                 <li class="nav-item"><a href="Core/Tools/Web/pages/about.html" class="nav-link">About PSL</a></li>
                 <li class="nav-item"><a href="Core/Tools/Web/pages/models.html" class="nav-link">Models</a></li>
-                <li class="nav-item"><a href="Core/Tools/Web/pages/donate.html" class="nav-link">Donate</a></li>
-                <li class="nav-item"><a href="Core/Tools/Web/pages/faq.html" class="nav-link">FAQ</a></li>
+                <!-- <li class="nav-item"><a href="Core/Tools/Web/pages/donate.html" class="nav-link">Donate</a></li>
+                <li class="nav-item"><a href="Core/Tools/Web/pages/faq.html" class="nav-link">FAQ</a></li> -->
             </ul>
         </nav>
         <div class="container">
-            <h1>Home</h1>
-            <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Aut, quo voluptatibus? Ea molestiae, nostrum esse magni dolore dolores minus atque ut at, est reiciendis, quam quasi nisi eos. Obcaecati, blanditiis!</p>
+            <div class="jumbotron" style="font-family:'Courier New', Courier, monospace">
+                <h1>Open Models == Better Policy</h1>
+                <a href="Core/Tools/Web/pages/about.html" class="btn btn-secondary btn-lg" id="aboutlink" style="font-family:'Courier New', Courier, monospace">About Us</a>
+            </div>
+            <div class="row">
+                <div class="col-lg-4">
+                    <a href="Core/Tools/Web/pages/models.html" class="card-link">
+                        <div class="card text-center">
+                            <div class="card-header">
+                                Explore the Models
+                            </div>
+                            <div class="card-body">
+                                <p>Learn about our open source models.</p>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-lg-4">
+                    <a href="#" class="card-link">
+                        <div class="card text-center">
+                            <div class="card-header">
+                                Contribute a Model
+                            </div>
+                            <div class="card-body">
+                                <p>Have a model you want to add to the library? See how to apply.</p>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <!-- <div class="col-lg-4">
+                    <a href="#" class="card-link">
+                        <div class="card text-center">
+                            <div class=card-header>
+                                Donate
+                            </div>
+                            <div class="card-body">
+                                Support open source policy analysis.
+                            </div>
+                        </div>
+                    </a>
+                </div> -->
+            </div>
+            <form>
+                <div class="form-group">
+                    <label for="news-letter-email">Join our news letter</label>
+                    <input type="email" class="form-control" id="news-letter-email" placeholder="email">
+                </div>
+                <div class="form-group form-check">
+                    <input type="checkbox" class="form-check-input" id="news-letter-check">
+                    <label for="news-letter-check" class="form-check-label">I agree to receive emails from PSL</label>
+                </div>
+                <button type="submit" class="btn btn-secondary">Submit</button>
+            </form>
         </div>
     </body>
 </html>


### PR DESCRIPTION
This PR updates the home page of the website and removes the donations and FAQ pages. I left the donation and FAQ pages in the repo so they can easily be added back and simply commented out any links to them. Now that I think about it, I'll update those pages to say "under construction" or "coming soon" on the off chance someone stumbles upon them.

Here's the new look:
![screen shot 2018-10-12 at 1 35 04 pm](https://user-images.githubusercontent.com/20684675/46884749-ed95e100-ce23-11e8-8f54-2830dde2a61d.png)

Obviously everything can be changed as we see fit. I had a third box for "donations" next to "Contribute a Model", but it's been removed for now. I think a third box would be nice to balance out the page.

When you click on "Explore the Models" it directs you to the models page. "Contribute a Model" is currently a dead link that can be updated when we have the contributor guide up.

@MattHJensen @hdoupe